### PR TITLE
feat: Table of Contents (ToC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,38 @@ for the rescue.
 
 Check all the supported functions in [KaTeX documentation](https://katex.org/docs/supported).
 
+## Table of Contents
+
+Posts automatically generate a table of contents from their headers.
+The ToC is responsive and switches between light and dark themes
+to match the site's overall design.
+
+### Usage
+
+By default, all posts with headers will display a ToC.
+You can control this behavior using metadata in your post's front matter:
+
+```yaml
+---
+title: "My Post"
+# Disable ToC for this post
+no-toc: true
+---
+```
+
+```yaml
+---
+title: "Research Post"
+# Set ToC depth (default: 3 levels)
+toc-depth: 2
+# Add References section to ToC if using bibliography
+bib: true
+---
+```
+
+The ToC appears between the post metadata and content,
+with automatic anchor links for easy navigation.
+
 ## License
 
 The code is [MIT](https://mit-license.org/)

--- a/blog/css/default.css
+++ b/blog/css/default.css
@@ -45,6 +45,71 @@ article .header {
   color: #555;
 }
 
+/* Table of Contents */
+.toc {
+  background-color: #f8f8f8;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  padding: 1rem 1.5rem;
+  margin: 1.5rem 0;
+  font-size: 1.4rem;
+}
+
+.toc-title {
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+  font-size: 1.6rem;
+}
+
+.toc ul {
+  list-style-type: none;
+  padding-left: 0;
+  margin: 0;
+}
+
+.toc li {
+  margin: 0.3rem 0;
+}
+
+.toc li ul {
+  padding-left: 1.5rem;
+  margin-top: 0.3rem;
+}
+
+.toc a {
+  text-decoration: none;
+  color: #333;
+  border-bottom: 1px dotted #999;
+}
+
+.toc a:hover {
+  color: #000;
+  border-bottom: 1px solid #000;
+}
+
+/* Dark mode support for ToC */
+@media (prefers-color-scheme: dark) {
+  .toc {
+    background-color: #222;
+    border: 1px solid #555;
+    color: #ddd;
+  }
+
+  .toc-title {
+    color: #ddd;
+  }
+
+  .toc a {
+    color: #bbb;
+    border-bottom: 1px dotted #666;
+  }
+
+  .toc a:hover {
+    color: #ddd;
+    border-bottom: 1px solid #888;
+  }
+}
+
 .logo a {
   font-weight: bold;
   color: #000;

--- a/blog/posts/2023-11-23-lindley_paradox.md
+++ b/blog/posts/2023-11-23-lindley_paradox.md
@@ -4,6 +4,7 @@ date: 2023-11-22
 author: Jose Storopoli
 description: Inside every non-Bayesian there is a Bayesian struggling to get out.
 tags: [math, bayesian, probability, julia]
+bib: true
 ---
 
 ![Dennis Lindley](/images/lindley.jpg)

--- a/blog/posts/2024-06-08-zkp.md
+++ b/blog/posts/2024-06-08-zkp.md
@@ -4,6 +4,7 @@ date: 2024-06-08
 author: Jose Storopoli
 description: An introduction to zero-knowledge proofs and their applications.
 tags: [cryptography, bitcoin]
+bib: true
 ---
 
 ![Zero-knowledge proofs and the meaning of life](/images/zkp_meme.jpg)

--- a/blog/posts/2024-11-15-taproot.md
+++ b/blog/posts/2024-11-15-taproot.md
@@ -3,6 +3,7 @@ title: Merkle trees and the Taproot protocol
 date: 2024-11-15
 author: Jose Storopoli
 tags: [math, cryptography, bitcoin]
+bib: true
 ---
 
 Dedicated to John Peter,

--- a/blog/posts/2025-02-10-bitvm.md
+++ b/blog/posts/2025-02-10-bitvm.md
@@ -4,6 +4,7 @@ date: 2025-02-10
 author: Jose Storopoli
 description: Intuition behind what's going on under the hood of BitVM.
 tags: [math, cryptography, bitcoin]
+bib: true
 ---
 
 This post is the written version of my very condensed 45-minute talk

--- a/blog/posts/2025-04-07-randomness.md
+++ b/blog/posts/2025-04-07-randomness.md
@@ -4,6 +4,7 @@ date: 2025-04-07
 author: Jose Storopoli
 description: How to make your own non-deterministic, but highly reliable, linear
 tags: [math, probability, programming, haskell]
+bib: true
 ---
 
 ![Just sprinkle a little bit of randomness, and voilà!](/images/randomness-meme.jpg)

--- a/blog/site.hs
+++ b/blog/site.hs
@@ -172,6 +172,7 @@ main = hakyllWith configuration $ do
 postCtx :: Context String
 postCtx =
   dateField "date" "%B %e, %Y"
+    `mappend` boolField "is-post" (const True)
     `mappend` defaultContext
 
 postCtxWithTags :: Tags -> Context String

--- a/blog/site.hs
+++ b/blog/site.hs
@@ -350,13 +350,14 @@ processBib pandoc = do
   p <- withItemBody (pure . setMeta "link-citations" True) pandoc
   fmap tableiseBib <$> processPandocBiblio csl bib p
 
--- | Align all citations in a table.
+-- | Align all citations in a table and add References header.
 tableiseBib :: Pandoc -> Pandoc
 tableiseBib = walk \case
   -- Citations start with a <div id="refs" …>
   Div a@("refs", _, _) body ->
-    -- No header needed, we just want to fill in the body contents.
-    Div a (Many.toList (simpleTable [] (map citToRow body)))
+    -- Add h2 header and table with citations
+    Div a $ Header 2 ("", [], []) [Str "References"] : 
+           Many.toList (simpleTable [] (map citToRow body))
   body -> body
   where
     citToRow :: Block -> [Many Block]
@@ -375,3 +376,5 @@ pandocCompiler' =
     ( traverse (pure . usingSideNotes <=< hlKaTeX)
         <=< processBib
     )
+
+--------------------------------------------------------------------------------

--- a/blog/templates/default.html
+++ b/blog/templates/default.html
@@ -38,6 +38,9 @@
         </main>
 
         <footer>
+            $if(is-post)$
+            <a href="#">↑ Go to top</a>
+            &nbsp;|&nbsp; $endif$
             <a href="/atom.xml" style="font-variant: small-caps">rss</a>
             &nbsp;|&nbsp;
             <a href="https://github.com/storopoli/storopoli.com"

--- a/blog/templates/post.html
+++ b/blog/templates/post.html
@@ -3,5 +3,11 @@
         Posted on $date$ $if(author)$ by $author$ $endif$
     </section>
     <div class="info">$if(tags)$ Tags: $tags$ $endif$</div>
+    $if(no-toc)$ $else$ $if(toc)$
+    <div id="table-of-contents" class="toc">
+        <p class="toc-title">Contents</p>
+        $toc$
+    </div>
+    $endif$ $endif$
     <section>$body$</section>
 </article>


### PR DESCRIPTION
Adds a Table of Contents feature for all posts:

- can be disabled with `no-toc: true` in the YAML frontmatter
- default depth is `3`
  - customizable with `toc-depth: N` in the YAML frontmatter
- adds "References" to the ToC with `bib: true` in the YAML frontmatter
- fix an issue where the "References" section does not have a header H2
- adds a "↑ Go to top" in the footer only in blogposts